### PR TITLE
Support for underline <u> HTML tag

### DIFF
--- a/CocoaMarkdown.xcodeproj/project.pbxproj
+++ b/CocoaMarkdown.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06D9F8771A70465700C00B67 /* CMHTMLUnderlineTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 06D9F8751A70465700C00B67 /* CMHTMLUnderlineTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06D9F8781A70465700C00B67 /* CMHTMLUnderlineTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 06D9F8751A70465700C00B67 /* CMHTMLUnderlineTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06D9F8791A70465700C00B67 /* CMHTMLUnderlineTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 06D9F8761A70465700C00B67 /* CMHTMLUnderlineTransformer.m */; };
+		06D9F87A1A70465700C00B67 /* CMHTMLUnderlineTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 06D9F8761A70465700C00B67 /* CMHTMLUnderlineTransformer.m */; };
 		720DA5811A68A00900DD05AF /* CocoaMarkdown.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 729F53FB1A68649200CC7448 /* CocoaMarkdown.framework */; };
 		720DA5821A68A01600DD05AF /* CocoaMarkdown.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 729F53FB1A68649200CC7448 /* CocoaMarkdown.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		722694BC1A687B4100E1D3DC /* test.md in Resources */ = {isa = PBXBuildFile; fileRef = 72FE7F171A686AC300F23F46 /* test.md */; };
@@ -297,6 +301,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06D9F8751A70465700C00B67 /* CMHTMLUnderlineTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMHTMLUnderlineTransformer.h; sourceTree = "<group>"; };
+		06D9F8761A70465700C00B67 /* CMHTMLUnderlineTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMHTMLUnderlineTransformer.m; sourceTree = "<group>"; };
 		722E33D31A68A0A5004DE919 /* Example-Mac-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Example-Mac-Bridging-Header.h"; sourceTree = "<group>"; };
 		722E33DE1A68E7E4004DE919 /* CMAttributeRun.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMAttributeRun.h; sourceTree = "<group>"; };
 		722E33DF1A68E7E4004DE919 /* CMAttributeRun.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMAttributeRun.m; sourceTree = "<group>"; };
@@ -516,6 +522,8 @@
 				72772BF01A6A28A70059936C /* CMHTMLScriptTransformer.h */,
 				72772BF11A6A28A70059936C /* CMHTMLScriptTransformer.m */,
 				72772BF61A6A29810059936C /* CMHTMLScriptTransformer_Private.h */,
+				06D9F8751A70465700C00B67 /* CMHTMLUnderlineTransformer.h */,
+				06D9F8761A70465700C00B67 /* CMHTMLUnderlineTransformer.m */,
 			);
 			name = HTML;
 			sourceTree = "<group>";
@@ -745,6 +753,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06D9F8771A70465700C00B67 /* CMHTMLUnderlineTransformer.h in Headers */,
 				722E33E61A68E86B004DE919 /* CMTextAttributes.h in Headers */,
 				72C17A991A6EBD7800212F17 /* CMDocument+HTMLAdditions.h in Headers */,
 				729F54301A6864F400CC7448 /* CMNode.h in Headers */,
@@ -787,6 +796,7 @@
 				729F54351A6864F400CC7448 /* CMParser.h in Headers */,
 				722E33E11A68E7E4004DE919 /* CMAttributeRun.h in Headers */,
 				722E33E71A68E86B004DE919 /* CMTextAttributes.h in Headers */,
+				06D9F8781A70465700C00B67 /* CMHTMLUnderlineTransformer.h in Headers */,
 				729F542B1A6864F400CC7448 /* CMIterator.h in Headers */,
 				729F54771A68652500CC7448 /* cmark.h in Headers */,
 				72FE7E961A6867F900F23F46 /* cmark_export.h in Headers */,
@@ -1136,6 +1146,7 @@
 				729F54281A6864F400CC7448 /* CMDocument.m in Sources */,
 				729F54711A68651E00CC7448 /* utf8.c in Sources */,
 				725116001A69735400337419 /* ONOXMLDocument.m in Sources */,
+				06D9F8791A70465700C00B67 /* CMHTMLUnderlineTransformer.m in Sources */,
 				72772BD81A699ACB0059936C /* CMHTMLUtilities.m in Sources */,
 				725115E21A6970A300337419 /* CMStack.m in Sources */,
 				72C17A951A6EBA3300212F17 /* CMHTMLRenderer.m in Sources */,
@@ -1192,6 +1203,7 @@
 				729F54291A6864F400CC7448 /* CMDocument.m in Sources */,
 				729F54721A68651E00CC7448 /* utf8.c in Sources */,
 				725116011A69735400337419 /* ONOXMLDocument.m in Sources */,
+				06D9F87A1A70465700C00B67 /* CMHTMLUnderlineTransformer.m in Sources */,
 				72772BD91A699ACB0059936C /* CMHTMLUtilities.m in Sources */,
 				725115E31A6970A300337419 /* CMStack.m in Sources */,
 				72C17A961A6EBA3300212F17 /* CMHTMLRenderer.m in Sources */,

--- a/CocoaMarkdown/CMHTMLUnderlineTransformer.h
+++ b/CocoaMarkdown/CMHTMLUnderlineTransformer.h
@@ -1,0 +1,46 @@
+//
+//  CMHTMLUnderlineTransformer.h
+//  CocoaMarkdown
+//
+//  Created by Damien Rambout on 19/01/15.
+//  Copyright (c) 2015 Indragie Karunaratne. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CMHTMLElementTransformer.h"
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#define CMColor UIColor
+#define CMUnderlineStyle NSUnderlineStyle
+#else
+#import <Cocoa/Cocoa.h>
+#define CMColor NSColor
+#define CMUnderlineStyle NSInteger
+#endif
+
+/**
+ Transforms HTML underline elements (<u>) into attributed strings.
+ */
+@interface CMHTMLUnderlineTransformer : NSObject <CMHTMLElementTransformer>
+
+/**
+ *  Initializes the receiver with the default attributes -- a single line
+ *  style and a color that matches the color of the text.
+ *
+ *  @return An initialized instance of the receiver.
+ */
+- (instancetype)init;
+
+/**
+ *  Initializes the receiver with a custom style and color.
+ *
+ *  @param style Strikethrough style.
+ *  @param color Strikethrough color. If `nil`, the transformer uses
+ *  the color of the text if it has been specified.
+ *
+ *  @return An initialized instance of the receiver.
+ */
+- (instancetype)initWithUnderlineStyle:(CMUnderlineStyle)style color:(CMColor *)color;
+
+@end

--- a/CocoaMarkdown/CMHTMLUnderlineTransformer.m
+++ b/CocoaMarkdown/CMHTMLUnderlineTransformer.m
@@ -1,0 +1,50 @@
+//
+//  CMHTMLUnderlineTransformer.m
+//  CocoaMarkdown
+//
+//  Created by Damien Rambout on 21/01/15.
+//  Copyright (c) 2015 Indragie Karunaratne. All rights reserved.
+//
+
+#import "CMHTMLUnderlineTransformer.h"
+#import "Ono.h"
+
+@implementation CMHTMLUnderlineTransformer {
+    CMUnderlineStyle _style;
+    CMColor *_color;
+}
+
+- (instancetype)init
+{
+    return [self initWithUnderlineStyle:NSUnderlineStyleSingle color:nil];
+}
+
+- (instancetype)initWithUnderlineStyle:(CMUnderlineStyle)style color:(CMColor *)color
+{
+    if ((self = [super init])) {
+        _style = style;
+        _color = color;
+    }
+    return self;
+}
+
+#pragma mark - CMHTMLElementTransformer
+
++ (NSString *)tagName { return @"u"; };
+
+- (NSAttributedString *)attributedStringForElement:(ONOXMLElement *)element attributes:(NSDictionary *)attributes
+{
+    CMAssertCorrectTag(element);
+    
+    NSMutableDictionary *allAttributes = [attributes mutableCopy];
+    allAttributes[NSUnderlineStyleAttributeName] = @(_style);
+    
+    CMColor *color = _color ?: allAttributes[NSForegroundColorAttributeName];
+    if (color != nil) {
+        allAttributes[NSUnderlineColorAttributeName] = color;
+    }
+    
+    return [[NSAttributedString alloc] initWithString:element.stringValue attributes:allAttributes];
+}
+
+@end

--- a/CocoaMarkdown/CocoaMarkdown.h
+++ b/CocoaMarkdown/CocoaMarkdown.h
@@ -20,6 +20,7 @@ FOUNDATION_EXPORT const unsigned char CocoaMarkdownVersionString[];
 #import <CocoaMarkdown/CMDocument+HTMLAdditions.h>
 #import <CocoaMarkdown/CMHTMLRenderer.h>
 #import <CocoaMarkdown/CMHTMLStrikethroughTransformer.h>
+#import <CocoaMarkdown/CMHTMLUnderlineTransformer.h>
 #import <CocoaMarkdown/CMHTMLSuperscriptTransformer.h>
 #import <CocoaMarkdown/CMHTMLSubscriptTransformer.h>
 #import <CocoaMarkdown/CMIterator.h>

--- a/CocoaMarkdownTests/Resources/test.md
+++ b/CocoaMarkdownTests/Resources/test.md
@@ -6,7 +6,7 @@ sit amet risus. Praesent co mmodo cursus magna, vel scelerisque nisl consectetur
 
 Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Nullam id dolor id nibh ultricies vehicula ut id elit. Sed posuere consectetur est at lobortis.
 
-Duis mollis, <s>est non commodo</s> luctus, nisi erat porttitor ligula, eget lacinia odio <sup>sem</sup> nec elit. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+Duis mollis, <s>est non commodo</s> luctus, nisi erat porttitor ligula, eget lacinia odio <sup>sem</sup> nec elit. <u>Morbi leo risus</u>, porta ac consectetur ac, vestibulum at eros.
 [Testing link](http://indragie.com "Indragie") and `inline code`.
 
 2. **Bold text**

--- a/Example-Mac/AppDelegate.swift
+++ b/Example-Mac/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())
         renderer.registerHTMLElementTransformer(CMHTMLStrikethroughTransformer())
         renderer.registerHTMLElementTransformer(CMHTMLSuperscriptTransformer())
+        renderer.registerHTMLElementTransformer(CMHTMLUnderlineTransformer())
         textView.textStorage?.appendAttributedString(renderer.render())
     }
 }

--- a/Example-iOS/ViewController.swift
+++ b/Example-iOS/ViewController.swift
@@ -19,6 +19,7 @@ class ViewController: UIViewController {
         let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())
         renderer.registerHTMLElementTransformer(CMHTMLStrikethroughTransformer())
         renderer.registerHTMLElementTransformer(CMHTMLSuperscriptTransformer())
+        renderer.registerHTMLElementTransformer(CMHTMLUnderlineTransformer())
         textView.attributedText = renderer.render()
     }
 }


### PR DESCRIPTION
I added a class `CMHTMLUnderlineTransformer` to support <u> HTML tag.
It should do it for issue #2.

By the way, I respected your coding conventions, but I would really suggest you to always use **properties** instead of instance variables, and use the **dot notation** instead of referencing instance variable using the underscore notation.