### PR TITLE
Small improvements to the HTML script transformers

### DIFF
--- a/CocoaMarkdown/CMHTMLScriptTransformer.m
+++ b/CocoaMarkdown/CMHTMLScriptTransformer.m
@@ -19,13 +19,15 @@
 @implementation CMHTMLScriptTransformer {
     CMHTMLScriptStyle _style;
     CGFloat _fontSizeRatio;
+    CGFloat _baselineOffset;
 }
 
-- (instancetype)initWithStyle:(CMHTMLScriptStyle)style fontSizeRatio:(CGFloat)ratio
+- (instancetype)initWithStyle:(CMHTMLScriptStyle)style fontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset
 {
     if ((self = [super init])) {
         _style = style;
         _fontSizeRatio = ratio;
+        _baselineOffset = offset;
     }
     return self;
 }
@@ -55,7 +57,10 @@
         font = [CMFont fontWithDescriptor:font.fontDescriptor size:font.pointSize * _fontSizeRatio];
         allAttributes[NSFontAttributeName] = font;
     }
-    
+    if (_baselineOffset != 0.0) {
+        allAttributes[NSBaselineOffsetAttributeName] = @(_baselineOffset);
+    }
+
     return [[NSAttributedString alloc] initWithString:element.stringValue attributes:allAttributes];
 }
 

--- a/CocoaMarkdown/CMHTMLScriptTransformer_Private.h
+++ b/CocoaMarkdown/CMHTMLScriptTransformer_Private.h
@@ -20,5 +20,5 @@ typedef NS_ENUM(NSInteger, CMHTMLScriptStyle) {
 };
 
 @interface CMHTMLScriptTransformer ()
-- (instancetype)initWithStyle:(CMHTMLScriptStyle)style fontSizeRatio:(CGFloat)ratio;
+- (instancetype)initWithStyle:(CMHTMLScriptStyle)style fontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset;
 @end

--- a/CocoaMarkdown/CMHTMLSubscriptTransformer.h
+++ b/CocoaMarkdown/CMHTMLSubscriptTransformer.h
@@ -37,4 +37,15 @@
  */
 - (instancetype)initWithFontSizeRatio:(CGFloat)ratio;
 
+/**
+ *  Initializes the receiver with a custom font size ratio and a custom baseline offset.
+ *
+ *  @param ratio The factor to multiply the existing font point
+ *  size by to calculate the size of the superscript font.
+ *  @param offset The offset for the baseline of the subscript.
+ *
+ *  @return An initialized instance of the receiver.
+ */
+- (instancetype)initWithFontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset;
+
 @end

--- a/CocoaMarkdown/CMHTMLSubscriptTransformer.m
+++ b/CocoaMarkdown/CMHTMLSubscriptTransformer.m
@@ -18,7 +18,7 @@
 
 - (instancetype)initWithFontSizeRatio:(CGFloat)ratio
 {
-    return [super initWithStyle:CMHTMLScriptStyleSuperscript fontSizeRatio:ratio];
+    return [super initWithStyle:CMHTMLScriptStyleSubscript fontSizeRatio:ratio];
 }
 
 #pragma mark - CMHTMLElementTransformer

--- a/CocoaMarkdown/CMHTMLSubscriptTransformer.m
+++ b/CocoaMarkdown/CMHTMLSubscriptTransformer.m
@@ -18,7 +18,12 @@
 
 - (instancetype)initWithFontSizeRatio:(CGFloat)ratio
 {
-    return [super initWithStyle:CMHTMLScriptStyleSubscript fontSizeRatio:ratio];
+    return [self initWithStyle:CMHTMLScriptStyleSubscript fontSizeRatio:ratio baselineOffset:0.0];
+}
+
+- (instancetype)initWithFontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset
+{
+    return [super initWithStyle:CMHTMLScriptStyleSubscript fontSizeRatio:ratio baselineOffset:offset];
 }
 
 #pragma mark - CMHTMLElementTransformer

--- a/CocoaMarkdown/CMHTMLSuperscriptTransformer.h
+++ b/CocoaMarkdown/CMHTMLSuperscriptTransformer.h
@@ -28,7 +28,7 @@
 - (instancetype)init;
 
 /**
- *  Initializes the receiver with a custom font size ratio.
+ *  Initializes the receiver with a custom font size ratio and a default baseline offset.
  *
  *  @param ratio The factor to multiply the existing font point
  *  size by to calculate the size of the superscript font.
@@ -36,5 +36,16 @@
  *  @return An initialized instance of the receiver.
  */
 - (instancetype)initWithFontSizeRatio:(CGFloat)ratio;
+
+/**
+ *  Initializes the receiver with a custom font size ratio and a custom baseline offset.
+ *
+ *  @param ratio The factor to multiply the existing font point
+ *  size by to calculate the size of the superscript font.
+ *  @param offset The offset for the baseline of the superscript.
+ *
+ *  @return An initialized instance of the receiver.
+ */
+- (instancetype)initWithFontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset;
 
 @end

--- a/CocoaMarkdown/CMHTMLSuperscriptTransformer.m
+++ b/CocoaMarkdown/CMHTMLSuperscriptTransformer.m
@@ -18,7 +18,12 @@
 
 - (instancetype)initWithFontSizeRatio:(CGFloat)ratio
 {
-    return [super initWithStyle:CMHTMLScriptStyleSuperscript fontSizeRatio:ratio];
+    return [self initWithStyle:CMHTMLScriptStyleSuperscript fontSizeRatio:ratio baselineOffset:0.0];
+}
+
+- (instancetype)initWithFontSizeRatio:(CGFloat)ratio baselineOffset:(CGFloat)offset
+{
+    return [super initWithStyle:CMHTMLScriptStyleSuperscript fontSizeRatio:ratio baselineOffset:offset];
 }
 
 #pragma mark - CMHTMLElementTransformer


### PR DESCRIPTION
There was a small bug that was initializing the CMHTMLSubscriptTransformer with the superscript style. I also added the ability to customize the baseline offset for the subscript and superscript.