### PR TITLE
Add podspec

### DIFF
--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -18,7 +18,7 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
   s.framework     = 'UIKit'
   s.requires_arc  = true
 
-  s.dependency 'cmark'
-  s.dependency 'Ono'
+  s.dependency 'cmark', '~> 0.21.0'
+  s.dependency 'Ono', '~> 1.1.3'
 
 end

--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -13,7 +13,7 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
   s.author        = "Indragie Karunaratne"
   s.platform      = :ios, '8.0'
 
-  s.source        = { :git => 'https://github.com/pronebird/CocoaMarkdown.git' }
+  s.source        = { :git => 'https://github.com/indragiek/CocoaMarkdown.git' }
   s.source_files  = 'CocoaMarkdown'
   s.framework     = 'UIKit'
   s.requires_arc  = true

--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+  
+  s.name          = 'CocoaMarkdown'
+  s.version       = '1.0'
+  s.summary       = 'Markdown parsing and rendering for iOS and OS X'
+  s.description   = "CocoaMarkdown aims to solve two primary problems better than existing libraries:
+More flexibility. CocoaMarkdown allows you to define custom parsing hooks or even traverse the Markdown AST using the low-level API.
+Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most existing libraries just generate HTML from the Markdown, which is not a convenient representation to work with in native apps."
+
+  s.homepage      = 'https://github.com/indragiek/CocoaMarkdown'
+  s.license       = 'MIT'
+
+  s.author        = "Indragie Karunaratne"
+  s.platform      = :ios, '8.0'
+
+  s.source        = { :git => 'https://github.com/pronebird/CocoaMarkdown.git' }
+  s.source_files  = 'CocoaMarkdown'
+  s.framework     = 'UIKit'
+  s.requires_arc  = true
+
+  s.dependency 'cmark'
+  s.dependency 'Ono'
+
+end

--- a/CocoaMarkdown/CocoaMarkdown.h
+++ b/CocoaMarkdown/CocoaMarkdown.h
@@ -27,5 +27,3 @@ FOUNDATION_EXPORT const unsigned char CocoaMarkdownVersionString[];
 #import <CocoaMarkdown/CMNode.h>
 #import <CocoaMarkdown/CMParser.h>
 #import <CocoaMarkdown/CMTextAttributes.h>
-
-#import <CocoaMarkdown/Ono.h>


### PR DESCRIPTION
Very minimal support for iOS only. I bet OS X should work out of box if we add `:osx` to pod spec but I didn't test. The source code is left untouched. I removed `CocoaMarkdown/Ono.h` from `CocoaMarkdown.h` because it's not used anywhere but in `CMAttributedStringRenderer.m` where it is included as `Ono.h` which should work just fine for the time being.

This work is based on @krodak's effort in #19  but takes into account the fact that you would like to keep submodules.

Good to have in future: 
1. Separate private headers from public. Currently pod spec includes the entire folder but I bet there were some private headers that normally should not be exposed.
2. Normalize import statements for dependencies, so they follow `<LIBRARY/LIBRARY.h>` pattern or something like that to avoid collisions.

After merge:

You would have to change the git URL in podspec, add tag to repo and put this tag in pod spec.

