### PR TITLE
Add CocoaPod support for os x

### DIFF
--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -11,7 +11,8 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
   s.license       = 'MIT'
 
   s.author        = "Indragie Karunaratne"
-  s.platform      = :ios, '8.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.11'
 
   s.source        = { :git => 'https://github.com/indragiek/CocoaMarkdown.git' }
   s.source_files  = 'CocoaMarkdown'

--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -17,7 +17,7 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
   s.source        = { :git => 'https://github.com/indragiek/CocoaMarkdown.git' }
   s.source_files  = 'CocoaMarkdown'
   s.private_header_files = 'CocoaMarkdown/*_Private.h'
-  s.framework     = 'UIKit'
+  s.ios.framework     = 'UIKit'
   s.requires_arc  = true
 
   s.dependency 'cmark', '~> 0.21.0'

--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -12,7 +12,7 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
 
   s.author        = "Indragie Karunaratne"
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.osx.deployment_target = '10.10'
 
   s.source        = { :git => 'https://github.com/indragiek/CocoaMarkdown.git' }
   s.source_files  = 'CocoaMarkdown'

--- a/CocoaMarkdown.podspec
+++ b/CocoaMarkdown.podspec
@@ -17,7 +17,8 @@ Efficient NSAttributedString creation for easy rendering on iOS and OS X. Most e
   s.source        = { :git => 'https://github.com/indragiek/CocoaMarkdown.git' }
   s.source_files  = 'CocoaMarkdown'
   s.private_header_files = 'CocoaMarkdown/*_Private.h'
-  s.ios.framework     = 'UIKit'
+  s.ios.framework = 'UIKit'
+  s.osx.framework = 'Cocoa'
   s.requires_arc  = true
 
   s.dependency 'cmark', '~> 0.21.0'


### PR DESCRIPTION
(This is the first time I'm using cocoa pods, so someone more familiar with it please verify this is correct).

I tried to use CocoaMarkdown with CocoaPods for an osx project and got an error that osx was not supported. The fix applied was recommended by [the cocoapods documentation](https://guides.cocoapods.org/syntax/podspec.html#platform).

The osx deployment target is almost certainly incorrect, however I did not know what the lowest supported version is. If someone tells me, I will update the pr.