### PR TITLE
Support for sublists in CMAttributedStringRenderer

### DIFF
--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -267,7 +267,9 @@
 
 - (void)parserDidEndListItem:(CMParser *)parser
 {
-    [self appendString:@"\n"];
+    if (parser.currentNode.next != nil || [self sublistLevel:parser.currentNode] == 1) {
+        [self appendString:@"\n"];
+    }
     [_attributeStack pop];
 }
 

--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -279,18 +279,25 @@
         return nil;
     }
     
-    NSMutableDictionary *listAttributes;
-    if (node.listType == CMListTypeOrdered) {
-        listAttributes = [_attributes.orderedListAttributes mutableCopy];
-    } else {
-        listAttributes = [_attributes.unorderedListAttributes mutableCopy];
+    NSUInteger sublistLevel = [self sublistLevel:node.parent];
+    if (sublistLevel == 0) {
+        return node.listType == CMListTypeOrdered ? _attributes.orderedListAttributes : _attributes.unorderedListAttributes;
     }
     
-    NSMutableParagraphStyle *paragraphStyle = [((NSParagraphStyle *)listAttributes[NSParagraphStyleAttributeName]) mutableCopy];
-    if (paragraphStyle != nil) {
-        NSUInteger sublistLevel = [self sublistLevel:node];
-        paragraphStyle.headIndent = paragraphStyle.headIndent * sublistLevel;
-        paragraphStyle.firstLineHeadIndent = paragraphStyle.firstLineHeadIndent * sublistLevel;
+    NSParagraphStyle *rootListParagraphStyle = [NSParagraphStyle defaultParagraphStyle];
+    NSMutableDictionary *listAttributes;
+    if (node.listType == CMListTypeOrdered) {
+        listAttributes = [_attributes.orderedSublistAttributes mutableCopy];
+        rootListParagraphStyle = _attributes.orderedListAttributes[NSParagraphStyleAttributeName];
+    } else {
+        listAttributes = [_attributes.unorderedSublistAttributes mutableCopy];
+        rootListParagraphStyle = _attributes.unorderedListAttributes[NSParagraphStyleAttributeName];
+    }
+    
+    if (listAttributes[NSParagraphStyleAttributeName] != nil) {
+        NSMutableParagraphStyle *paragraphStyle = [((NSParagraphStyle *)listAttributes[NSParagraphStyleAttributeName]) mutableCopy];
+        paragraphStyle.headIndent = rootListParagraphStyle.headIndent + paragraphStyle.headIndent * sublistLevel;
+        paragraphStyle.firstLineHeadIndent = rootListParagraphStyle.firstLineHeadIndent + paragraphStyle.firstLineHeadIndent * sublistLevel;
         listAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
     }
     

--- a/CocoaMarkdown/CMTextAttributes.h
+++ b/CocoaMarkdown/CMTextAttributes.h
@@ -151,6 +151,26 @@
 @property (nonatomic) NSDictionary *unorderedListAttributes;
 
 /**
+ *  Attributes used to style ordered sublists.
+ *
+ *  These attributes will apply to the entire list (unless overriden by attributes
+ *  for the list items), including the numbers.
+ *
+ *  Defaults to using a paragraph style with a head indent of 30px.
+ */
+@property (nonatomic) NSDictionary *orderedSublistAttributes;
+
+/**
+ *  Attributes used to style unordered sublists.
+ *
+ *  These attributes will apply to the entire list (unless overriden by attributes
+ *  for the list items), including the bullets.
+ *
+ *  Defaults to using a paragraph style with a head indent of 30px.
+ */
+@property (nonatomic) NSDictionary *unorderedSublistAttributes;
+
+/**
  *  Attributes used to style ordered list items.
  *
  *  These attribtues do _not_ apply to the numbers.

--- a/CocoaMarkdown/CMTextAttributes.m
+++ b/CocoaMarkdown/CMTextAttributes.m
@@ -136,6 +136,16 @@ static NSDictionary * CMDefaultUnorderedListAttributes()
     return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
 }
 
+static NSDictionary * CMDefaultOrderedSublistAttributes()
+{
+    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+}
+
+static NSDictionary * CMDefaultUnorderedSublistAttributes()
+{
+    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+}
+
 @implementation CMTextAttributes
 
 - (instancetype)init
@@ -154,6 +164,8 @@ static NSDictionary * CMDefaultUnorderedListAttributes()
         _blockQuoteAttributes = CMDefaultBlockQuoteAttributes();
         _orderedListAttributes = CMDefaultOrderedListAttributes();
         _unorderedListAttributes = CMDefaultUnorderedListAttributes();
+        _orderedSublistAttributes = CMDefaultOrderedSublistAttributes();
+        _unorderedSublistAttributes = CMDefaultUnorderedSublistAttributes();
     }
     return self;
 }

--- a/CocoaMarkdownTests/Resources/test.md
+++ b/CocoaMarkdownTests/Resources/test.md
@@ -17,6 +17,9 @@ Here is another list:
 
 * Unordered
 * list
+    - With
+    - a
+    - sublist
 
 ![Image](https://raw.githubusercontent.com/sonoramac/Sonora/master/screenshot.png "screenshot")
 

--- a/CocoaMarkdownTests/Resources/test.md
+++ b/CocoaMarkdownTests/Resources/test.md
@@ -16,10 +16,11 @@ Duis mollis, <s>est non commodo</s> luctus, nisi erat porttitor ligula, eget lac
 Here is another list:
 
 * Unordered
+    - sublist
 * list
     - With
-    - a
-    - sublist
+    - two
+    - sublists
 
 ![Image](https://raw.githubusercontent.com/sonoramac/Sonora/master/screenshot.png "screenshot")
 

--- a/Example-iOS/ViewController.swift
+++ b/Example-iOS/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         let path = NSBundle.mainBundle().pathForResource("test", ofType: "md")!
-        let document = CMDocument(contentsOfFile: path, options: nil)
+        let document = CMDocument(contentsOfFile: path, options: CMDocumentOptions(rawValue: 0))
         let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())
         renderer.registerHTMLElementTransformer(CMHTMLStrikethroughTransformer())
         renderer.registerHTMLElementTransformer(CMHTMLSuperscriptTransformer())


### PR DESCRIPTION
I added the support for sublists rendering in `CMAttributedStringRenderer`.