### PR TITLE
Tweaks to attributed string rendering

### DIFF
--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -201,7 +201,7 @@
 
 - (void)parserFoundSoftBreak:(CMParser *)parser
 {
-    [self appendString:@"\n"];
+    [self appendString:@" "];
 }
 
 - (void)parserFoundLineBreak:(CMParser *)parser

--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -102,12 +102,20 @@
 
 - (void)parserDidStartParagraph:(CMParser *)parser
 {
-    [self appendLineBreakIfNotTightForNode:parser.currentNode];
+    if (![self nodeIsInTightMode:parser.currentNode]) {
+        NSMutableParagraphStyle* paragraphStyle = [NSMutableParagraphStyle new];
+        paragraphStyle.paragraphSpacingBefore = 12;
+        
+        [_attributeStack push:CMDefaultAttributeRun(@{NSParagraphStyleAttributeName: paragraphStyle})];
+    }
 }
 
 - (void)parserDidEndParagraph:(CMParser *)parser
 {
-    [self appendLineBreakIfNotTightForNode:parser.currentNode];
+    if (![self nodeIsInTightMode:parser.currentNode]) {
+        [_attributeStack pop];
+        [self appendString:@"\n"];
+    }
 }
 
 - (void)parserDidStartEmphasis:(CMParser *)parser
@@ -327,12 +335,10 @@
     return nil;
 }
 
-- (void)appendLineBreakIfNotTightForNode:(CMNode *)node
+- (BOOL)nodeIsInTightMode:(CMNode *)node
 {
     CMNode *grandparent = node.parent.parent;
-    if (!grandparent.listTight) {
-        [self appendString:@"\n"];
-    }
+    return grandparent.listTight;
 }
 
 - (void)appendString:(NSString *)string


### PR DESCRIPTION
1. Fixes a problem where soft breaks were always converted into newlines. Note that in the [spec](softbreaks) says that soft breaks may generate newlines in a rendered HTML document, and that HTML collapses all whitespace (including newlines) down to a single space character. Instead of converting into a newline, we convert into a space.

2. Improves (IMO, feel free to disagree) handling of paragraphs. In HTML rendering ([spec](paragraphs)), paragraphs are naturally rendered as `<p>hello world</p>`, not `<br />hello world<br />`, so I've changed the handling to use paragraph spacing (`NSParagraphStyle.paragraphSpacing`) to create the little extra space between paragraphs.

Feedback is welcome!

[softbreaks]: http://spec.commonmark.org/0.25/#soft-line-breaks
[paragraphs]: http://spec.commonmark.org/0.25/#paragraphs