### PR TITLE
Fix line break separator

### DIFF
--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -214,7 +214,7 @@
 
 - (void)parserFoundLineBreak:(CMParser *)parser
 {
-    [self appendString:@"\n"];
+    [self appendString:@"\u2028"];
 }
 
 - (void)parserDidStartBlockQuote:(CMParser *)parser


### PR DESCRIPTION
Based on [apple mailing list](http://lists.apple.com/archives/Cocoa-dev/2010/Dec/msg00347.html) you should use unicode line separator symbol for line breaks. `\n` is used for paragraph separation.

Here's my paragraph style:

```
paragraphStyle.lineSpacing = 0;
paragraphStyle.paragraphSpacing = 10;
```

Example markdown:

```
## Text with linebreaks
Lorem ipsum dolor sit amet, consectetur adipiscing elit,  
sed do eiusmod tempor incididunt ut labore et dolore magna  
aliqua. Ut enim ad minim veniam, quis nostrud exercitation  
ullamco laboris nisi ut aliquip ex ea commodo consequat. 

Duis aute irure dolor in reprehenderit in voluptate velit  
esse cillum dolore eu fugiat nulla pariatur.  
Excepteur sint occaecat cupidatat non proident, sunt in  
culpa qui officia deserunt mollit anim id est laborum.
```

Result before my commit:
![img_1301](https://cloud.githubusercontent.com/assets/8555000/16736027/58e571c0-479c-11e6-8ec9-1e02ca24cd1f.PNG)

And result after commit:
![img_1300](https://cloud.githubusercontent.com/assets/8555000/16736002/451545e4-479c-11e6-94f5-a50fb047cfa5.PNG)
