### PR TITLE
Fix invalid cmdocument options in osx example

### DIFF
--- a/Example-Mac/AppDelegate.swift
+++ b/Example-Mac/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         let path = NSBundle.mainBundle().pathForResource("test", ofType: "md")!
-        let document = CMDocument(contentsOfFile: path, options: nil)
+        let document = CMDocument(contentsOfFile: path, options: CMDocumentOptions(rawValue: 0))
         let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())
         renderer.registerHTMLElementTransformer(CMHTMLStrikethroughTransformer())
         renderer.registerHTMLElementTransformer(CMHTMLSuperscriptTransformer())


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1086845/18492303/a561ae18-7a1b-11e6-8c09-7e451a2d09bc.png)
