### PR TITLE
Dynamic Type compatibility of default code styles on iOS.

### DIFF
--- a/CocoaMarkdown/CMTextAttributes.m
+++ b/CocoaMarkdown/CMTextAttributes.m
@@ -133,10 +133,18 @@ static NSDictionary * CMDefaultImageParagraphAttributes()
 }
 
 #if TARGET_OS_IPHONE
-static UIFont * MonospaceFont()
+static UIFont * defaultMonospaceFont()
 {
-    CGFloat size = [[UIFont preferredFontForTextStyle:UIFontTextStyleBody] pointSize];
-    return [UIFont fontWithName:@"Menlo" size:size] ?: [UIFont fontWithName:@"Courier" size:size];
+    if (@available(iOS 11.0, *)) {
+        CGFloat baseFontSize = [UIFont preferredFontForTextStyle:UIFontTextStyleBody 
+                                   compatibleWithTraitCollection:[UITraitCollection traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryMedium]].pointSize;
+        UIFont* baseMonospaceFont = [UIFont fontWithName:@"Menlo" size:baseFontSize] ?: [UIFont fontWithName:@"Courier" size:baseFontSize];
+        return [[UIFontMetrics metricsForTextStyle:UIFontTextStyleBody] scaledFontForFont:baseMonospaceFont];
+    } else {
+        // Fallback on earlier versions
+        CGFloat size = [[UIFont preferredFontForTextStyle:UIFontTextStyleBody] pointSize];
+        return [UIFont fontWithName:@"Menlo" size:size] ?: [UIFont fontWithName:@"Courier" size:size];
+    }
 }
 #endif
 
@@ -152,7 +160,7 @@ static NSDictionary * CMDefaultCodeBlockAttributes()
 {
     return @{
 #if TARGET_OS_IPHONE
-        NSFontAttributeName: MonospaceFont(),
+        NSFontAttributeName: defaultMonospaceFont(),
 #else
         NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0],
 #endif
@@ -163,7 +171,7 @@ static NSDictionary * CMDefaultCodeBlockAttributes()
 static NSDictionary * CMDefaultInlineCodeAttributes()
 {
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: MonospaceFont()};
+    return @{NSFontAttributeName: defaultMonospaceFont()};
 #else
     return @{NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0]};
 #endif

--- a/Example-iOS/Base.lproj/Main.storyboard
+++ b/Example-iOS/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,8 +19,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="97c-zT-yS4">
-                                <rect key="frame" x="16" y="20" width="343" height="627"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="97c-zT-yS4">
+                                <rect key="frame" x="16" y="0.0" width="343" height="647"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -43,6 +41,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="142" y="134"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
On iOS 11 and above, this PR sets a scalable monospace font for inline code and code blocks default attributes.

The iOS example app is also updated to activate automatic-font-adjustment in the text view, so its becomes Dynamic-Type-compliant.