### PR TITLE
Flexible styling of attributed string renderer

### DIFF
--- a/CocoaMarkdown.xcodeproj/project.pbxproj
+++ b/CocoaMarkdown.xcodeproj/project.pbxproj
@@ -1787,7 +1787,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.indragie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1804,7 +1804,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Example-iOS/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.indragie.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CocoaMarkdown/CMAttributeRun.h
+++ b/CocoaMarkdown/CMAttributeRun.h
@@ -9,18 +9,17 @@
 #import <Foundation/Foundation.h>
 #import "CMPlatformDefines.h"
 
+@class CMStyleAttributes;
+
 @interface CMAttributeRun : NSObject
-@property (nonatomic, readonly) NSDictionary *attributes;
-@property (nonatomic, readonly) CMFontSymbolicTraits fontTraits;
+@property (nonatomic, readonly) CMStyleAttributes *attributes;
 @property (nonatomic) NSInteger orderedListItemNumber;
 @property (nonatomic, readonly) BOOL listTight;
 
-- (instancetype)initWithAttributes:(NSDictionary *)attributes
-                        fontTraits:(CMFontSymbolicTraits)fontTraits
+- (instancetype)initWithAttributes:(CMStyleAttributes *)attributes
                  orderedListNumber:(NSInteger)orderedListNumber;
 
 @end
 
-CMAttributeRun * CMDefaultAttributeRun(NSDictionary *attributes);
-CMAttributeRun * CMTraitAttributeRun(NSDictionary *attributes, CMFontSymbolicTraits traits);
-CMAttributeRun * CMOrderedListAttributeRun(NSDictionary *attributes, NSInteger startingNumber);
+CMAttributeRun * CMDefaultAttributeRun(CMStyleAttributes *attributes);
+CMAttributeRun * CMOrderedListAttributeRun(CMStyleAttributes *attributes, NSInteger startingNumber);

--- a/CocoaMarkdown/CMAttributeRun.m
+++ b/CocoaMarkdown/CMAttributeRun.m
@@ -8,30 +8,23 @@
 
 #import "CMAttributeRun.h"
 
-CMAttributeRun * CMDefaultAttributeRun(NSDictionary *attributes)
+CMAttributeRun * CMDefaultAttributeRun(CMStyleAttributes *attributes)
 {
-    return [[CMAttributeRun alloc] initWithAttributes:attributes fontTraits:0 orderedListNumber:0];
+    return [[CMAttributeRun alloc] initWithAttributes:attributes orderedListNumber:0];
 }
 
-CMAttributeRun * CMTraitAttributeRun(NSDictionary *attributes, CMFontSymbolicTraits traits)
+CMAttributeRun * CMOrderedListAttributeRun(CMStyleAttributes *attributes, NSInteger startingNumber)
 {
-    return [[CMAttributeRun alloc] initWithAttributes:attributes fontTraits:traits orderedListNumber:0];
-}
-
-CMAttributeRun * CMOrderedListAttributeRun(NSDictionary *attributes, NSInteger startingNumber)
-{
-    return [[CMAttributeRun alloc] initWithAttributes:attributes fontTraits:0 orderedListNumber:startingNumber];
+    return [[CMAttributeRun alloc] initWithAttributes:attributes orderedListNumber:startingNumber];
 }
 
 @implementation CMAttributeRun
 
-- (instancetype)initWithAttributes:(NSDictionary *)attributes
-                        fontTraits:(CMFontSymbolicTraits)fontTraits
+- (instancetype)initWithAttributes:(CMStyleAttributes *)attributes
                  orderedListNumber:(NSInteger)orderedListNumber
 {
     if ((self = [super init])) {
         _attributes = attributes;
-        _fontTraits = fontTraits;
         _orderedListItemNumber = orderedListNumber;
     }
     return self;

--- a/CocoaMarkdown/CMCascadingAttributeStack.h
+++ b/CocoaMarkdown/CMCascadingAttributeStack.h
@@ -8,13 +8,15 @@
 
 #import <Foundation/Foundation.h>
 
+@class CMStyleAttributes;
 @class CMAttributeRun;
 
 @interface CMCascadingAttributeStack : NSObject
 @property (nonatomic, readonly) NSDictionary *cascadedAttributes;
 
-- (void)push:(CMAttributeRun *)run;
-- (CMAttributeRun *)pop;
+- (void) pushAttributes:(CMStyleAttributes*)attributes;
+- (void) pushOrderedListAttributes:(CMStyleAttributes*)attributes withStartingNumber:(NSInteger)startingNumber;
+- (void)pop;
 - (CMAttributeRun *)peek;
 
 @end

--- a/CocoaMarkdown/CMCascadingAttributeStack.m
+++ b/CocoaMarkdown/CMCascadingAttributeStack.m
@@ -10,24 +10,17 @@
 #import "CMAttributeRun.h"
 #import "CMPlatformDefines.h"
 #import "CMStack.h"
+#import "CMTextAttributes.h"
 
-static CMFont * CMFontWithTraits(CMFontSymbolicTraits traits, CMFont *font)
-{
-    CMFontSymbolicTraits combinedTraits = font.fontDescriptor.symbolicTraits | (traits & 0xFFFF);
-#if TARGET_OS_IPHONE
-    UIFontDescriptor *descriptor = [font.fontDescriptor fontDescriptorWithSymbolicTraits:combinedTraits];
-    return [UIFont fontWithDescriptor:descriptor size:font.pointSize];
-#else
-    NSDictionary *attributes = @{
-        NSFontFamilyAttribute: font.familyName,
-        NSFontTraitsAttribute: @{
-            NSFontSymbolicTrait: @(combinedTraits)
-        },
-    };
-    NSFontDescriptor *descriptor = [NSFontDescriptor fontDescriptorWithFontAttributes:attributes];
-    return [NSFont fontWithDescriptor:descriptor size:font.pointSize];
-#endif
-}
+@interface CMFont (CMAdditions)
+- (CMFont*) fontByAddingCMAttributes:(NSDictionary<CMFontDescriptorAttributeName, id>*)addedFontAttributes;
+@end
+
+@interface NSParagraphStyle (CMAdditions)
++ (NSParagraphStyle*) paragraphStyleWithCMAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes;
+- (NSParagraphStyle*) paragraphStyleByAddingCMAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes;
+@end
+
 
 @implementation CMCascadingAttributeStack {
     CMStack *_stack;
@@ -42,16 +35,26 @@ static CMFont * CMFontWithTraits(CMFontSymbolicTraits traits, CMFont *font)
     return self;
 }
 
+- (void) pushAttributes:(CMStyleAttributes*)attributes
+{
+    [self push:CMDefaultAttributeRun(attributes)];
+}
+
+- (void) pushOrderedListAttributes:(CMStyleAttributes*)attributes withStartingNumber:(NSInteger)startingNumber
+{
+    [self push:CMOrderedListAttributeRun(attributes, startingNumber)];
+}
+
 - (void)push:(CMAttributeRun *)run
 {
     [_stack push:run];
     _cascadedAttributes = nil;
 }
 
-- (CMAttributeRun *)pop
+- (void)pop
 {
     _cascadedAttributes = nil;
-    return [_stack pop];
+    [_stack pop];
 }
 
 - (CMAttributeRun *)peek
@@ -62,24 +65,239 @@ static CMFont * CMFontWithTraits(CMFontSymbolicTraits traits, CMFont *font)
 - (NSDictionary *)cascadedAttributes
 {
     if (_cascadedAttributes == nil) {
-        NSMutableDictionary *allAttributes = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary *combinedAttributes = [[NSMutableDictionary alloc] init];
+        
         for (CMAttributeRun *run in _stack.objects) {
-            CMFont *baseFont;
-            CMFont *adjustedFont;
-            if (run.fontTraits != 0 &&
-                (baseFont = allAttributes[NSFontAttributeName]) &&
-                (adjustedFont = CMFontWithTraits(run.fontTraits, baseFont))) {
-                
-                NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithDictionary:run.attributes];
-                attributes[NSFontAttributeName] = adjustedFont;
-                [allAttributes addEntriesFromDictionary:attributes];
-            } else if (run.attributes != nil) {
-                [allAttributes addEntriesFromDictionary:run.attributes];
+            CMStyleAttributes * currentStyleAttributes = run.attributes;
+            
+            // Set explicit string attributes
+            [combinedAttributes addEntriesFromDictionary:currentStyleAttributes.stringAttributes];
+            
+            // Set font attributes
+            if (currentStyleAttributes.fontAttributes.count > 0) {
+                CMFont *baseFont = combinedAttributes[NSFontAttributeName];
+                CMFont *adjustedFont = nil;
+                if (baseFont != nil) {
+                    adjustedFont = [baseFont fontByAddingCMAttributes:currentStyleAttributes.fontAttributes];
+                }
+                else {
+                    CMFontDescriptor * adjustedFontDescriptor = [CMFontDescriptor fontDescriptorWithFontAttributes:currentStyleAttributes.fontAttributes];
+                    if (adjustedFontDescriptor != nil) {
+                        adjustedFont = [CMFont fontWithDescriptor:adjustedFontDescriptor size:adjustedFontDescriptor.pointSize];
+                    }
+                }
+                if (adjustedFont != nil) {
+                    combinedAttributes[NSFontAttributeName] = adjustedFont;
+                }
+            }
+            
+            // Set paragraph style attributes
+            if (currentStyleAttributes.paragraphStyleAttributes.count > 0) {
+                NSParagraphStyle* baseParagraphStyle = combinedAttributes[NSParagraphStyleAttributeName];
+                NSParagraphStyle* adjustedParagraphStyle = nil;
+                if (baseParagraphStyle != nil) {
+                    adjustedParagraphStyle = [baseParagraphStyle paragraphStyleByAddingCMAttributes:currentStyleAttributes.paragraphStyleAttributes];
+                }
+                else {
+                    adjustedParagraphStyle = [NSParagraphStyle paragraphStyleWithCMAttributes:currentStyleAttributes.paragraphStyleAttributes];
+                }
+                if (adjustedParagraphStyle != nil) {
+                    combinedAttributes[NSParagraphStyleAttributeName] = adjustedParagraphStyle;
+                }
             }
         }
-        _cascadedAttributes = allAttributes;
+        
+        _cascadedAttributes = combinedAttributes;
     }
     return _cascadedAttributes;
+}
+
+@end
+
+
+@implementation CMFont (CMAdditions)
+
+#if TARGET_OS_IPHONE
+#define CMFontNameAttribute UIFontDescriptorNameAttribute
+#define CMFontFamilyAttribute UIFontDescriptorFamilyAttribute
+#define CMFontTraitsAttribute UIFontDescriptorTraitsAttribute
+#define CMFontDescriptorTraitKey UIFontDescriptorTraitKey
+#define CMFontSymbolicTraitKey UIFontSymbolicTrait
+
+#else
+#define CMFontNameAttribute NSFontNameAttribute
+#define CMFontFamilyAttribute NSFontFamilyAttribute
+#define CMFontTraitsAttribute NSFontTraitsAttribute
+#define CMFontDescriptorTraitKey NSFontDescriptorTraitKey
+#define CMFontSymbolicTraitKey NSFontSymbolicTrait
+#endif
+
+
+- (CMFont*) fontByAddingCMAttributes:(NSDictionary<CMFontDescriptorAttributeName, id>*)addedFontAttributes
+{
+    CMFont* matchingFont = nil;
+    CMFontDescriptor* currentFontDescriptor = self.fontDescriptor;
+    
+#if TARGET_OS_IPHONE
+    // Get the current font text style
+    UIFontTextStyle currentFontTextStyle = [currentFontDescriptor objectForKey:UIFontDescriptorTextStyleAttribute] ?: UIFontTextStyleBody;
+#endif
+    
+    if ([addedFontAttributes isKindOfClass:[NSDictionary class]] && (addedFontAttributes.count > 0)) {
+        NSMutableDictionary<CMFontDescriptorAttributeName, id>* fontAttributes = [currentFontDescriptor.fontAttributes mutableCopy];
+        
+        if (((addedFontAttributes[CMFontTraitsAttribute] != nil) || (addedFontAttributes[CMFontFamilyAttribute] != nil)) 
+            && (addedFontAttributes[CMFontNameAttribute] == nil)) {
+            // Replace the font name in the font attributes by font-family
+            fontAttributes[CMFontFamilyAttribute] = [currentFontDescriptor objectForKey:CMFontFamilyAttribute];
+            [fontAttributes removeObjectForKey:CMFontNameAttribute];
+        }
+        
+        if ((addedFontAttributes[CMFontFamilyAttribute] != nil) || (addedFontAttributes[CMFontNameAttribute] != nil)) {
+            // A font is specified in the added attributes: Remove an eventual text-style font attribute as it could break the font change
+#if TARGET_OS_IPHONE
+            [fontAttributes removeObjectForKey:UIFontDescriptorTextStyleAttribute];
+#else
+            [fontAttributes removeObjectForKey:@"NSCTFontUIUsageAttribute"];
+#endif
+        }
+        
+        // Add the parameter attributes
+        [fontAttributes addEntriesFromDictionary:addedFontAttributes];
+        
+        // If only font traits are added, try to preserve current font traits
+        BOOL hasCombinedFontTraits = NO;
+        NSDictionary<CMFontDescriptorTraitKey, id>* addedFontTraits = addedFontAttributes[CMFontTraitsAttribute];
+        NSDictionary<CMFontDescriptorTraitKey, id>* currentFontTraits;
+        if ((addedFontTraits != nil) && (addedFontAttributes.count == 1)) {
+            currentFontTraits = [currentFontDescriptor objectForKey:CMFontTraitsAttribute];
+            NSUInteger currentSymbolicTraits = [currentFontTraits[CMFontSymbolicTraitKey] unsignedIntValue];
+            NSUInteger addedSymbolicTraits = [addedFontTraits[CMFontSymbolicTraitKey] unsignedIntValue];
+            
+            NSMutableDictionary<CMFontDescriptorTraitKey, id>* combinedFontTraits = [NSMutableDictionary new];
+            [currentFontTraits enumerateKeysAndObjectsUsingBlock:^(CMFontDescriptorTraitKey traitKey, id traitValue, BOOL * _Nonnull stop) {
+                if (![traitKey isEqualToString:CMFontSymbolicTraitKey] && ([traitValue doubleValue] != 0)) {
+                    // Only keep traits with non-default value
+                    combinedFontTraits[traitKey] = traitValue;
+                }
+            }];
+            [combinedFontTraits addEntriesFromDictionary:addedFontAttributes[CMFontTraitsAttribute]];
+            // Combine symbolic traits
+            if ((currentSymbolicTraits != 0) && (addedSymbolicTraits != 0)) {
+                combinedFontTraits[CMFontSymbolicTraitKey] = @(currentSymbolicTraits | addedSymbolicTraits);
+            }
+            fontAttributes[CMFontTraitsAttribute] = combinedFontTraits;
+            hasCombinedFontTraits = YES;
+        }
+        
+        // Get a font descriptor with the transformed font attributes
+        CMFontDescriptor* matchingFontDescriptor = [CMFontDescriptor fontDescriptorWithFontAttributes:fontAttributes];
+        
+        if (hasCombinedFontTraits && (matchingFontDescriptor != nil)) {
+            // Check if the font descriptor consistently creates a font with the expected font family
+            NSString* expectedFontFamily = [matchingFontDescriptor objectForKey:CMFontFamilyAttribute];
+            NSString* resultingFontFamily = [[CMFont fontWithDescriptor:matchingFontDescriptor size:0].fontDescriptor objectForKey:CMFontFamilyAttribute];
+            if (! [resultingFontFamily isEqualToString:expectedFontFamily]) {
+                // Retry without font traits attribute inheritance
+                fontAttributes [CMFontTraitsAttribute] = addedFontTraits;
+                matchingFontDescriptor = [CMFontDescriptor fontDescriptorWithFontAttributes:fontAttributes];
+                
+                // If added font traits break the expected font familly, ignore them
+                resultingFontFamily = [[CMFont fontWithDescriptor:matchingFontDescriptor size:0].fontDescriptor objectForKey:CMFontFamilyAttribute];
+                if (! [resultingFontFamily isEqualToString:expectedFontFamily]) {
+                    // Restore current font traits
+                    fontAttributes [CMFontTraitsAttribute] = currentFontTraits;
+                    matchingFontDescriptor = [CMFontDescriptor fontDescriptorWithFontAttributes:fontAttributes];
+                }
+            }            
+        }
+        
+        if (matchingFontDescriptor != nil) {
+    
+#if TARGET_OS_IPHONE
+            if (@available(iOS 11.0, *)) {
+                CGFloat currentStyleFontSize = [UIFont preferredFontForTextStyle:currentFontTextStyle].pointSize;
+                CGFloat currentStyleBaseFontSize = [UIFont preferredFontForTextStyle:currentFontTextStyle 
+                                                compatibleWithTraitCollection:[UITraitCollection traitCollectionWithPreferredContentSizeCategory:UIContentSizeCategoryMedium]].pointSize;
+                UIFont* nonScalableFont = [UIFont fontWithDescriptor:matchingFontDescriptor 
+                                                                size:matchingFontDescriptor.pointSize * currentStyleBaseFontSize / currentStyleFontSize];
+                matchingFont = [[UIFontMetrics metricsForTextStyle:currentFontTextStyle] scaledFontForFont:nonScalableFont];
+            }
+            else {
+                matchingFont = [UIFont fontWithDescriptor:matchingFontDescriptor size:matchingFontDescriptor.pointSize];
+            }
+#else   
+            matchingFont = [CMFont fontWithDescriptor:matchingFontDescriptor size:matchingFontDescriptor.pointSize];
+#endif
+
+        }
+    }
+
+    return matchingFont;
+}
+
+@end
+
+
+#pragma mark - NSParagraphStyle additions
+
+@interface NSMutableParagraphStyle (CMAdditions)
+- (void) applyParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes;
+@end
+
+@implementation NSParagraphStyle (CMAdditions)
+
++ (NSParagraphStyle*) paragraphStyleWithCMAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes
+{
+    NSMutableParagraphStyle* newParagraphStyle = nil;
+    if ([paragraphStyleAttributes isKindOfClass:[NSDictionary class]] && (paragraphStyleAttributes.count > 0)) {
+        newParagraphStyle = [NSMutableParagraphStyle new];
+        [newParagraphStyle applyParagraphStyleAttributes:paragraphStyleAttributes];
+    }
+    return newParagraphStyle;
+}
+
+- (NSParagraphStyle*) paragraphStyleByAddingCMAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes
+{
+    NSMutableParagraphStyle* newParagraphStyle = nil;
+    if ([paragraphStyleAttributes isKindOfClass:[NSDictionary class]] && (paragraphStyleAttributes.count > 0)) {
+        newParagraphStyle = [self mutableCopy];
+        [newParagraphStyle applyParagraphStyleAttributes:paragraphStyleAttributes];
+    }
+    return newParagraphStyle;
+}
+
+@end
+
+@implementation NSMutableParagraphStyle (CMAdditions)
+
+- (void) applyParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id> *)paragraphStyleAttributes
+{
+    static NSDictionary* applyAttributeBlocks;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        applyAttributeBlocks = 
+        @{ CMParagraphStyleAttributeLineSpacing: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.lineSpacing = [attribute doubleValue]; },
+           CMParagraphStyleAttributeParagraphSpacing: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.paragraphSpacing = [attribute doubleValue]; },
+           CMParagraphStyleAttributeAlignment: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.alignment = (NSTextAlignment)[attribute integerValue]; },
+           CMParagraphStyleAttributeLineBreakMode: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.lineBreakMode = (NSLineBreakMode)[attribute integerValue]; },
+           CMParagraphStyleAttributeMinimumLineHeight: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.minimumLineHeight = [attribute doubleValue]; },
+           CMParagraphStyleAttributeMaximumLineHeight: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.maximumLineHeight = [attribute doubleValue]; },
+           CMParagraphStyleAttributeLineHeightMultiple: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.lineHeightMultiple = [attribute doubleValue]; },
+           CMParagraphStyleAttributeParagraphSpacingBefore: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.paragraphSpacingBefore = [attribute doubleValue]; },
+           CMParagraphStyleAttributeHyphenationFactor: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.hyphenationFactor = [attribute floatValue]; },
+           // Attributes with defining increment values
+           CMParagraphStyleAttributeFirstLineHeadExtraIndent: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.firstLineHeadIndent += [attribute doubleValue]; },
+           CMParagraphStyleAttributeHeadExtraIndent: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.headIndent += [attribute doubleValue]; },
+           CMParagraphStyleAttributeTailExtraIndent: ^(NSMutableParagraphStyle* paragraphStyle, id attribute){ paragraphStyle.tailIndent += [attribute doubleValue]; },
+           
+        };
+    });
+    
+    [paragraphStyleAttributes enumerateKeysAndObjectsUsingBlock:^(CMParagraphStyleAttributeName attributeName, id attributeValue, BOOL * _Nonnull stop) {
+        
+        ((void(^)(NSMutableParagraphStyle* paragraphStyle, id attribute))applyAttributeBlocks[attributeName])(self, attributeValue);
+    }];
 }
 
 @end

--- a/CocoaMarkdown/CMPlatformDefines.h
+++ b/CocoaMarkdown/CMPlatformDefines.h
@@ -16,9 +16,13 @@
 #define CMFontSymbolicTraits UIFontDescriptorSymbolicTraits
 #define CMFont UIFont
 #define CMFontDescriptor UIFontDescriptor
+#define CMFontTraitsAttribute UIFontDescriptorTraitsAttribute
 #define CMFontTraitItalic UIFontDescriptorTraitItalic
 #define CMFontTraitBold UIFontDescriptorTraitBold
 #define CMUnderlineStyle NSUnderlineStyle
+
+typedef UIFontDescriptorAttributeName CMFontDescriptorAttributeName;
+typedef UIFontDescriptorTraitKey CMFontDescriptorTraitKey;
 
 #else
 #import <Cocoa/Cocoa.h>
@@ -27,9 +31,13 @@
 #define CMFontSymbolicTraits NSFontSymbolicTraits
 #define CMFont NSFont
 #define CMFontDescriptor NSFontDescriptor
+#define CMFontTraitsAttribute NSFontTraitsAttribute
 #define CMFontTraitItalic NSFontItalicTrait
 #define CMFontTraitBold NSFontBoldTrait
 #define CMUnderlineStyle NSInteger
+
+typedef NSFontDescriptorAttributeName CMFontDescriptorAttributeName;
+typedef NSFontDescriptorTraitKey CMFontDescriptorTraitKey;
 
 #endif
 

--- a/CocoaMarkdown/CMTextAttributes.h
+++ b/CocoaMarkdown/CMTextAttributes.h
@@ -8,6 +8,38 @@
 
 #import <Foundation/Foundation.h>
 
+#import "CMPlatformDefines.h"
+
+typedef NS_OPTIONS(NSUInteger, CMElementKind) {
+    CMElementKindText = 1 << 0,
+    
+    CMElementKindHeader1 = 1 << 1,
+    CMElementKindHeader2 = 1 << 2,
+    CMElementKindHeader3 = 1 << 3,
+    CMElementKindHeader4 = 1 << 4,
+    CMElementKindHeader5 = 1 << 5,
+    CMElementKindHeader6 = 1 << 6,
+    CMElementKindAnyHeader = CMElementKindHeader1 | CMElementKindHeader2 | CMElementKindHeader3 | CMElementKindHeader4 | CMElementKindHeader5 | CMElementKindHeader6,
+    
+    CMElementKindParagraph = 1 << 7,
+    CMElementKindLink = 1 << 8,
+    CMElementKindImageParagraph = 1 << 9,
+    CMElementKindCodeBlock = 1 << 10,
+    CMElementKindInlineCode = 1 << 11,
+    CMElementKindBlockQuote = 1 << 12,
+    
+    CMElementKindOrderedList = 1 << 13,
+    CMElementKindOrderedSublist = 1 << 14,
+    CMElementKindOrderedListItem = 1 << 15,
+    CMElementKindUnorderedList = 1 << 16,
+    CMElementKindUnorderedSublist = 1 << 17,
+    CMElementKindUnorderedListItem = 1 << 18,
+};
+
+@class CMStyleAttributes;
+
+typedef NSString * CMParagraphStyleAttributeName NS_EXTENSIBLE_STRING_ENUM;
+
 /**
  *  Container for sets of text attributes used to style 
  *  attributed strings.
@@ -21,12 +53,41 @@
  */
 - (instancetype)init;
 
+/// Set additional attributes for one or more element-kind
+/// 
+/// @param attributes A dictionary of string attributes that will be added to existing attributes for every specified element kind
+/// @param elementKind The mask of target element kinds
+///
+- (void) addStringAttributes:(NSDictionary<NSAttributedStringKey, id>*)attributes forElementWithKinds:(CMElementKind)elementKinds;
+
+/// Set additional font attributes for one or more element-kind
+/// 
+/// @param attributes A dictionary of font-descriptor attributes that will be added to existing attributes for every specified element kind
+/// @param elementKind The mask of target element kinds
+///
+- (void) addFontAttributes:(NSDictionary<CMFontDescriptorAttributeName, id>*)fontAttributes forElementWithKinds:(CMElementKind)elementKinds;
+
+/// Set font traits for one or more element-kind
+/// 
+/// @param fontTraits A dictionary of font-trait attributes that will be set for every specified element kind
+/// @param elementKind The mask of target element kinds
+/// @description This is a specialized version of `addFontAttributes:forElementWithKinds:` dedicated to the font-trait attribute
+///
+- (void) setFontTraits:(NSDictionary<CMFontDescriptorTraitKey, id>*)fontTraits forElementWithKinds:(CMElementKind)elementKinds;
+
+/// Set additional paragraph attributes for one or more element-kind
+/// 
+/// @param attributes A dictionary of string attributes that will be added to existing attributes for every specified element kind
+/// @param elementKind The mask of target element kinds
+///
+- (void) addParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)attributes forElementWithKinds:(CMElementKind)elementKinds;
+
 /**
  *  @param level The header level.
  *
  *  @return The attributes for the specified header level.
  */
-- (NSDictionary *)attributesForHeaderLevel:(NSInteger)level;
+- (CMStyleAttributes *)attributesForHeaderLevel:(NSInteger)level;
 
 /**
  *  Attributes used to style text.
@@ -34,7 +95,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleBody`
  *  On OS X, defaults to using the user font with size 12pt.
  */
-@property (nonatomic) NSDictionary *textAttributes;
+@property (nonatomic) CMStyleAttributes *baseTextAttributes;
 
 /**
  *  Attributes used to style level 1 headers.
@@ -42,7 +103,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleHeadline`
  *  On OS X, defaults to using the user font with size 24pt.
  */
-@property (nonatomic) NSDictionary *h1Attributes;
+@property (nonatomic) CMStyleAttributes *h1Attributes;
 
 /**
  *  Attributes used to style level 2 headers.
@@ -50,7 +111,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleHeadline`
  *  On OS X, defaults to using the user font with size 18pt.
  */
-@property (nonatomic) NSDictionary *h2Attributes;
+@property (nonatomic) CMStyleAttributes *h2Attributes;
 
 /**
  *  Attributes used to style level 3 headers.
@@ -58,7 +119,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleHeadline`
  *  On OS X, defaults to using the user font with size 14pt.
  */
-@property (nonatomic) NSDictionary *h3Attributes;
+@property (nonatomic) CMStyleAttributes *h3Attributes;
 
 /**
  *  Attributes used to style level 4 headers.
@@ -66,7 +127,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleSubheadline`
  *  On OS X, defaults to using the user font with size 12pt.
  */
-@property (nonatomic) NSDictionary *h4Attributes;
+@property (nonatomic) CMStyleAttributes *h4Attributes;
 
 /**
  *  Attributes used to style level 5 headers.
@@ -74,7 +135,7 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleSubheadline`
  *  On OS X, defaults to using the user font with size 10pt.
  */
-@property (nonatomic) NSDictionary *h5Attributes;
+@property (nonatomic) CMStyleAttributes *h5Attributes;
 
 /**
  *  Attributes used to style level 6 headers.
@@ -82,14 +143,14 @@
  *  On iOS, defaults to using the Dynamic Type font with style `UIFontTextStyleSubheadline`
  *  On OS X, defaults to using the user font with size 8pt.
  */
-@property (nonatomic) NSDictionary *h6Attributes;
+@property (nonatomic) CMStyleAttributes *h6Attributes;
 
 /**
  *  Attributes used to style paragraphs.
  *
  *  Defaults to using a 12pt paragraph spacing
  */
-@property (nonatomic) NSDictionary *paragraphAttributes;
+@property (nonatomic) CMStyleAttributes *paragraphAttributes;
 
 /**
  *  Attributes used to style emphasized text.
@@ -97,7 +158,7 @@
  *  If not set, the renderer will attempt to infer the emphasized font from the
  *  regular text font.
  */
-@property (nonatomic) NSDictionary *emphasisAttributes;
+@property (nonatomic) CMStyleAttributes *emphasisAttributes;
 
 /**
  *  Attributes used to style strong text.
@@ -105,14 +166,14 @@
  *  If not set, the renderer will attempt to infer the strong font from the
  *  regular text font.
  */
-@property (nonatomic) NSDictionary *strongAttributes;
+@property (nonatomic) CMStyleAttributes *strongAttributes;
 
 /**
  *  Attributes used to style linked text.
  *
  *  Defaults to using a blue foreground color and a single line underline style.
  */
-@property (nonatomic) NSDictionary *linkAttributes;
+@property (nonatomic) CMStyleAttributes *linkAttributes;
 
 
 /**
@@ -120,7 +181,7 @@
  *
  *  Defaults to centering the image.
  */
-@property (nonatomic) NSDictionary *imageParagraphAttributes;
+@property (nonatomic) CMStyleAttributes *imageParagraphAttributes;
 
 /**
  *  Attributes used to style code blocks.
@@ -128,7 +189,7 @@
  *  On iOS, defaults to the Menlo font when available, or Courier as a fallback.
  *  On OS X, defaults to the user monospaced font.
  */
-@property (nonatomic) NSDictionary *codeBlockAttributes;
+@property (nonatomic) CMStyleAttributes *codeBlockAttributes;
 
 /**
  *  Attributes used to style inline code.
@@ -136,14 +197,14 @@
  *  On iOS, defaults to the Menlo font when available, or Courier as a fallback.
  *  On OS X, defaults to the user monospaced font.
  */
-@property (nonatomic) NSDictionary *inlineCodeAttributes;
+@property (nonatomic) CMStyleAttributes *inlineCodeAttributes;
 
 /**
  *  Attributes used to style block quotes.
  *
  *  Defaults to using a paragraph style with a head indent of 30px.
  */
-@property (nonatomic) NSDictionary *blockQuoteAttributes;
+@property (nonatomic) CMStyleAttributes *blockQuoteAttributes;
 
 /**
  *  Attributes used to style ordered lists.
@@ -153,7 +214,7 @@
  *
  *  Defaults to using a paragraph style with a head indent of 30px.
  */
-@property (nonatomic) NSDictionary *orderedListAttributes;
+@property (nonatomic) CMStyleAttributes *orderedListAttributes;
 
 /**
  *  Attributes used to style unordered lists.
@@ -163,7 +224,7 @@
  *
  *  Defaults to using a paragraph style with a head indent of 30px.
  */
-@property (nonatomic) NSDictionary *unorderedListAttributes;
+@property (nonatomic) CMStyleAttributes *unorderedListAttributes;
 
 /**
  *  Attributes used to style ordered sublists.
@@ -173,7 +234,7 @@
  *
  *  Defaults to using a paragraph style with a head indent of 30px.
  */
-@property (nonatomic) NSDictionary *orderedSublistAttributes;
+@property (nonatomic) CMStyleAttributes *orderedSublistAttributes;
 
 /**
  *  Attributes used to style unordered sublists.
@@ -183,20 +244,46 @@
  *
  *  Defaults to using a paragraph style with a head indent of 30px.
  */
-@property (nonatomic) NSDictionary *unorderedSublistAttributes;
+@property (nonatomic) CMStyleAttributes *unorderedSublistAttributes;
 
 /**
  *  Attributes used to style ordered list items.
  *
  *  These attribtues do _not_ apply to the numbers.
  */
-@property (nonatomic) NSDictionary *orderedListItemAttributes;
+@property (nonatomic) CMStyleAttributes *orderedListItemAttributes;
 
 /**
  *  Attributes used to style unordered list items.
  *
  *  These attribtues do _not_ apply to the bullets.
  */
-@property (nonatomic) NSDictionary *unorderedListItemAttributes;
+@property (nonatomic) CMStyleAttributes *unorderedListItemAttributes;
 
 @end
+
+
+@interface CMStyleAttributes: NSObject <NSCopying>
+
+@property (readonly) NSMutableDictionary<NSAttributedStringKey, id> * stringAttributes;
+@property (readonly) NSMutableDictionary<CMFontDescriptorAttributeName, id> * fontAttributes;
+@property (readonly) NSMutableDictionary<CMParagraphStyleAttributeName, id> * paragraphStyleAttributes;
+
+// Helper method for setting specific symbolic traits in fontAttributes
+- (void) setFontSymbolicTraits:(CMFontSymbolicTraits)fontSymbolicTraits;
+
+@end
+
+
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineSpacing;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeParagraphSpacing;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeAlignment;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeFirstLineHeadExtraIndent;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeHeadExtraIndent;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeTailExtraIndent;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineBreakMode;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeMinimumLineHeight;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeMaximumLineHeight;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineHeightMultiple;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeParagraphSpacingBefore;
+extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeHyphenationFactor;

--- a/CocoaMarkdown/CMTextAttributes.h
+++ b/CocoaMarkdown/CMTextAttributes.h
@@ -10,6 +10,8 @@
 
 #import "CMPlatformDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_OPTIONS(NSUInteger, CMElementKind) {
     CMElementKindText = 1 << 0,
     
@@ -287,3 +289,5 @@ extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeMaximumLineH
 extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineHeightMultiple;
 extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeParagraphSpacingBefore;
 extern CMParagraphStyleAttributeName const CMParagraphStyleAttributeHyphenationFactor;
+
+NS_ASSUME_NONNULL_END

--- a/CocoaMarkdown/CMTextAttributes.m
+++ b/CocoaMarkdown/CMTextAttributes.m
@@ -9,127 +9,121 @@
 #import "CMTextAttributes.h"
 #import "CMPlatformDefines.h"
 
-static NSDictionary * CMDefaultTextAttributes()
+@interface CMStyleAttributes ()
+
+- (instancetype) initWithStringAttributes:(NSDictionary<NSAttributedStringKey, id>*) textAttributes;
+- (instancetype) initWithStringAttributes:(NSDictionary<NSAttributedStringKey, id>*) textAttributes paragraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)paragraphStyleAttributes;
+- (instancetype) initWithParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)paragraphStyleAttributes;
+- (instancetype) initWithFontSymbolicTraits:(CMFontSymbolicTraits)fontSymbolicTraits;
+
+@end
+
+static CMStyleAttributes * CMDefaultBaseTextAttributes()
 {
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleBody]};
+    stringAttributes = @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleBody]};
 #else
-    return @{NSFontAttributeName: [NSFont userFontOfSize:12.0]};
+    stringAttributes = @{NSFontAttributeName: [NSFont userFontOfSize:12.0]};
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes];
 }
 
-static NSMutableParagraphStyle* defaultHeaderParagraphStyle()
+static NSDictionary<CMParagraphStyleAttributeName, id> * defaultHeaderParagraphStyleAttributes()
 {
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    paragraphStyle.paragraphSpacingBefore = 16;
-    paragraphStyle.paragraphSpacing = 8;
-    return paragraphStyle;
+    return @{ CMParagraphStyleAttributeParagraphSpacingBefore: @16,
+              CMParagraphStyleAttributeParagraphSpacing: @8 };
 }
 
-static NSDictionary * CMDefaultH1Attributes()
+static CMStyleAttributes * CMDefaultH1Attributes()
 {
-    NSMutableParagraphStyle* h1ParagraphStyle = defaultHeaderParagraphStyle();
-    h1ParagraphStyle.paragraphSpacingBefore = 28;
-    h1ParagraphStyle.paragraphSpacing = 14;
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline],
-             NSParagraphStyleAttributeName: h1ParagraphStyle };
+    stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1] };
 #else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:28.0],
-             NSParagraphStyleAttributeName: h1ParagraphStyle };
+    stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:28.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:@{ CMParagraphStyleAttributeParagraphSpacingBefore: @28,
+                                                                  CMParagraphStyleAttributeParagraphSpacing: @14 }];
 }
 
-static NSDictionary * CMDefaultH2Attributes()
+static CMStyleAttributes * CMDefaultH2Attributes()
 {
-    NSMutableParagraphStyle* h2ParagraphStyle = defaultHeaderParagraphStyle();
-    h2ParagraphStyle.paragraphSpacingBefore = 20;
-    h2ParagraphStyle.paragraphSpacing = 10;
+    NSDictionary* stringAttributes;
+    #if TARGET_OS_IPHONE
+        stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleTitle2] };
+    #else
+        stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:22.0] };
+    #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:@{ CMParagraphStyleAttributeParagraphSpacingBefore: @20,
+                                                                  CMParagraphStyleAttributeParagraphSpacing: @10 }];
+}
+
+static CMStyleAttributes * CMDefaultH3Attributes()
+{
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline],
-             NSParagraphStyleAttributeName: h2ParagraphStyle};
+    stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleTitle3] };
 #else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:22.0],
-             NSParagraphStyleAttributeName: h2ParagraphStyle,
-             };
+    stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:defaultHeaderParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultH3Attributes()
+static CMStyleAttributes * CMDefaultH4Attributes()
 {
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle() };
+    stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline] };
 #else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:16.0],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle(),
-             };
+    stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:14.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:defaultHeaderParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultH4Attributes()
+static CMStyleAttributes * CMDefaultH5Attributes()
 {
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle() };
+    stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline] };
 #else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:14.0],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle(),
-             };
+    stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:12.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:defaultHeaderParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultH5Attributes()
+static CMStyleAttributes * CMDefaultH6Attributes()
 {
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle() };
+    stringAttributes = @{ NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline] };
 #else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:12.0],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle(),
-             };
+    stringAttributes = @{ NSFontAttributeName: [NSFont boldSystemFontOfSize:10.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:defaultHeaderParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultH6Attributes()
+static CMStyleAttributes * CMDefaultParagraphAttributes()
 {
-#if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle() };
-#else
-    return @{NSFontAttributeName: [NSFont boldSystemFontOfSize:10.0],
-             NSParagraphStyleAttributeName: defaultHeaderParagraphStyle(),
-             };
-#endif
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:@{ CMParagraphStyleAttributeParagraphSpacingBefore: @12 }];
 }
 
-static NSDictionary * CMDefaultParagraphAttributes()
+static CMStyleAttributes * CMDefaultLinkAttributes()
 {
-    NSMutableParagraphStyle* paragraphStyle = [NSMutableParagraphStyle new];
-    paragraphStyle.paragraphSpacingBefore = 12;
-    
-    return @{NSParagraphStyleAttributeName: paragraphStyle};
+    return [[CMStyleAttributes alloc] initWithStringAttributes:@{ NSForegroundColorAttributeName: CMColor.blueColor,
+                                                                  NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle) }];
 }
 
-static NSDictionary * CMDefaultLinkAttributes()
+static CMStyleAttributes * CMDefaultImageParagraphAttributes()
 {
-    return @{
-#if TARGET_OS_IPHONE
-        NSForegroundColorAttributeName: UIColor.blueColor,
-#else
-        NSForegroundColorAttributeName: NSColor.blueColor,
-#endif
-        NSUnderlineStyleAttributeName: @(NSUnderlineStyleSingle)
-    };
-}
-
-static NSDictionary * CMDefaultImageParagraphAttributes()
-{
-    NSMutableParagraphStyle* paragraphStyle = [NSMutableParagraphStyle new];
-    paragraphStyle.paragraphSpacingBefore = 12;
-    paragraphStyle.alignment = NSTextAlignmentCenter;
-    
-    return @{NSParagraphStyleAttributeName: paragraphStyle};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:@{ CMParagraphStyleAttributeParagraphSpacingBefore: @12,
+                                                                          CMParagraphStyleAttributeAlignment: @(NSTextAlignmentCenter) }];
 }
 
 #if TARGET_OS_IPHONE
@@ -148,58 +142,63 @@ static UIFont * defaultMonospaceFont()
 }
 #endif
 
-static NSParagraphStyle * DefaultIndentedParagraphStyle()
+static NSDictionary<CMParagraphStyleAttributeName, id> * DefaultIndentedParagraphStyleAttributes()
 {
-    NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-    style.firstLineHeadIndent = 30;
-    style.headIndent = 30;
-    return style;
+    return @{ CMParagraphStyleAttributeFirstLineHeadExtraIndent: @30,
+              CMParagraphStyleAttributeHeadExtraIndent: @30 };
 }
 
-static NSDictionary * CMDefaultCodeBlockAttributes()
+static CMStyleAttributes * CMDefaultCodeBlockAttributes()
 {
-    return @{
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-        NSFontAttributeName: defaultMonospaceFont(),
+    stringAttributes = @{ NSFontAttributeName: defaultMonospaceFont(), };
 #else
-        NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0],
+    stringAttributes = @{ NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0] };
 #endif
-        NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()
-    };
+
+    NSMutableDictionary* paragraphStyleAttributes = [NSMutableDictionary new];
+    [paragraphStyleAttributes addEntriesFromDictionary:DefaultIndentedParagraphStyleAttributes()];
+    paragraphStyleAttributes[CMParagraphStyleAttributeParagraphSpacingBefore] = @12;
+    
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes 
+                                      paragraphStyleAttributes:paragraphStyleAttributes];
 }
 
-static NSDictionary * CMDefaultInlineCodeAttributes()
+static CMStyleAttributes * CMDefaultInlineCodeAttributes()
 {
+    NSDictionary* stringAttributes;
 #if TARGET_OS_IPHONE
-    return @{NSFontAttributeName: defaultMonospaceFont()};
+    stringAttributes = @{ NSFontAttributeName: defaultMonospaceFont(), };
 #else
-    return @{NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0]};
+    stringAttributes = @{ NSFontAttributeName: [NSFont userFixedPitchFontOfSize:12.0] };
 #endif
+    return [[CMStyleAttributes alloc] initWithStringAttributes:stringAttributes];
 }
 
-static NSDictionary * CMDefaultBlockQuoteAttributes()
+static  CMStyleAttributes *  CMDefaultBlockQuoteAttributes()
 {
-    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:DefaultIndentedParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultOrderedListAttributes()
+static  CMStyleAttributes *  CMDefaultOrderedListAttributes()
 {
-    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:DefaultIndentedParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultUnorderedListAttributes()
+static  CMStyleAttributes *  CMDefaultUnorderedListAttributes()
 {
-    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:DefaultIndentedParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultOrderedSublistAttributes()
+static  CMStyleAttributes *  CMDefaultOrderedSublistAttributes()
 {
-    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:DefaultIndentedParagraphStyleAttributes()];
 }
 
-static NSDictionary * CMDefaultUnorderedSublistAttributes()
+static  CMStyleAttributes *  CMDefaultUnorderedSublistAttributes()
 {
-    return @{NSParagraphStyleAttributeName: DefaultIndentedParagraphStyle()};
+    return [[CMStyleAttributes alloc] initWithParagraphStyleAttributes:DefaultIndentedParagraphStyleAttributes()];
 }
 
 @implementation CMTextAttributes
@@ -207,7 +206,7 @@ static NSDictionary * CMDefaultUnorderedSublistAttributes()
 - (instancetype)init
 {
     if ((self = [super init])) {
-        _textAttributes = CMDefaultTextAttributes();
+        _baseTextAttributes = CMDefaultBaseTextAttributes();
         _h1Attributes = CMDefaultH1Attributes();
         _h2Attributes = CMDefaultH2Attributes();
         _h3Attributes = CMDefaultH3Attributes();
@@ -215,6 +214,10 @@ static NSDictionary * CMDefaultUnorderedSublistAttributes()
         _h5Attributes = CMDefaultH5Attributes();
         _h6Attributes = CMDefaultH6Attributes();
         _paragraphAttributes = CMDefaultParagraphAttributes();
+        
+        _emphasisAttributes = [[CMStyleAttributes alloc] initWithFontSymbolicTraits:CMFontTraitItalic];
+        _strongAttributes = [[CMStyleAttributes alloc] initWithFontSymbolicTraits:CMFontTraitBold];
+        
         _linkAttributes = CMDefaultLinkAttributes();
         _imageParagraphAttributes = CMDefaultImageParagraphAttributes();
         _codeBlockAttributes = CMDefaultCodeBlockAttributes();
@@ -228,7 +231,96 @@ static NSDictionary * CMDefaultUnorderedSublistAttributes()
     return self;
 }
 
-- (NSDictionary *)attributesForHeaderLevel:(NSInteger)level
+- (void) updateAttributesForElementKinds:(CMElementKind)elementKinds usingBlock:(void(^)(CMStyleAttributes * styleAttributes))block
+{
+    if ((elementKinds & CMElementKindText) != 0) {
+        block(_baseTextAttributes);
+    }
+    if ((elementKinds & CMElementKindHeader1) != 0) {
+        block(_h1Attributes);
+    }
+    if ((elementKinds & CMElementKindHeader2) != 0) {
+        block(_h2Attributes);
+    }
+    if ((elementKinds & CMElementKindHeader3) != 0) {
+        block(_h3Attributes);
+    }
+    if ((elementKinds & CMElementKindHeader4) != 0) {
+        block(_h4Attributes);
+    }
+    if ((elementKinds & CMElementKindHeader5) != 0) {
+        block(_h5Attributes);
+    }
+    if ((elementKinds & CMElementKindHeader6) != 0) {
+        block(_h6Attributes);
+    }
+    if ((elementKinds & CMElementKindParagraph) != 0) {
+        block(_paragraphAttributes);
+    }
+    if ((elementKinds & CMElementKindLink) != 0) {
+        block(_linkAttributes);
+    }
+    if ((elementKinds & CMElementKindImageParagraph) != 0) {
+        block(_imageParagraphAttributes);
+    }
+    if ((elementKinds & CMElementKindCodeBlock) != 0) {
+        block(_codeBlockAttributes);
+    }
+    if ((elementKinds & CMElementKindInlineCode) != 0) {
+        block(_inlineCodeAttributes);
+    }
+    if ((elementKinds & CMElementKindBlockQuote) != 0) {
+        block(_blockQuoteAttributes);
+    }
+    if ((elementKinds & CMElementKindOrderedList) != 0) {
+        block(_orderedListAttributes);
+    }
+    if ((elementKinds & CMElementKindOrderedSublist) != 0) {
+        block(_orderedSublistAttributes);
+    }
+    if ((elementKinds & CMElementKindOrderedListItem) != 0) {
+        block(_orderedListItemAttributes);
+    }
+    if ((elementKinds & CMElementKindUnorderedList) != 0) {
+        block(_unorderedListAttributes);
+    }
+    if ((elementKinds & CMElementKindUnorderedSublist) != 0) {
+        block(_unorderedSublistAttributes);
+    }
+    if ((elementKinds & CMElementKindUnorderedListItem) != 0) {
+        block(_unorderedListItemAttributes);
+    }
+}
+
+- (void) addStringAttributes:(NSDictionary<NSAttributedStringKey, id>*)attributes forElementWithKinds:(CMElementKind)elementKinds
+{
+    [self updateAttributesForElementKinds:elementKinds usingBlock:^(CMStyleAttributes *styleAttributes) {
+        [styleAttributes.stringAttributes addEntriesFromDictionary:attributes];
+    }];
+}
+
+- (void) addFontAttributes:(NSDictionary<CMFontDescriptorAttributeName, id>*)fontAttributes forElementWithKinds:(CMElementKind)elementKinds
+{
+    [self updateAttributesForElementKinds:elementKinds usingBlock:^(CMStyleAttributes *styleAttributes) {
+        [styleAttributes.fontAttributes addEntriesFromDictionary:fontAttributes];
+    }];
+}
+
+- (void) setFontTraits:(NSDictionary<CMFontDescriptorTraitKey, id>*)fontTraits forElementWithKinds:(CMElementKind)elementKinds
+{
+    [self updateAttributesForElementKinds:elementKinds usingBlock:^(CMStyleAttributes *styleAttributes) {
+        styleAttributes.fontAttributes[CMFontTraitsAttribute] = fontTraits;
+    }];
+}
+
+- (void) addParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)attributes forElementWithKinds:(CMElementKind)elementKinds
+{
+    [self updateAttributesForElementKinds:elementKinds usingBlock:^(CMStyleAttributes *styleAttributes) {
+        [styleAttributes.paragraphStyleAttributes addEntriesFromDictionary:attributes];
+    }];
+}
+
+- (CMStyleAttributes *)attributesForHeaderLevel:(NSInteger)level
 {
     switch (level) {
         case 1: return _h1Attributes;
@@ -241,3 +333,104 @@ static NSDictionary * CMDefaultUnorderedSublistAttributes()
 }
 
 @end
+
+
+@implementation CMStyleAttributes
+
+- (instancetype) init
+{
+    self = [super init];
+    if (self != nil) {
+        _stringAttributes = [NSMutableDictionary new];
+        _fontAttributes = [NSMutableDictionary new];
+        _paragraphStyleAttributes =[NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (instancetype) initWithStringAttributes:(NSDictionary<NSAttributedStringKey,id> *)stringAttributes
+{
+    self = [self init];
+    if (self != nil) {
+        [_stringAttributes addEntriesFromDictionary:stringAttributes];
+    }
+    return self;
+}
+
+- (instancetype) initWithParagraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)paragraphStyleAttributes
+{
+    self = [self init];
+    if (self != nil) {
+        [_paragraphStyleAttributes addEntriesFromDictionary:paragraphStyleAttributes];
+    }
+    return self;
+}
+
+- (instancetype) initWithStringAttributes:(NSDictionary<NSAttributedStringKey, id>*)stringAttributes
+                 paragraphStyleAttributes:(NSDictionary<CMParagraphStyleAttributeName, id>*)paragraphStyleAttributes
+{
+    self = [self init];
+    if (self != nil) {
+        [_stringAttributes addEntriesFromDictionary:stringAttributes];
+        [_paragraphStyleAttributes addEntriesFromDictionary:paragraphStyleAttributes];
+    }
+    return self;    
+}
+
+- (instancetype) initWithFontSymbolicTraits:(CMFontSymbolicTraits)fontSymbolicTraits
+{
+    self = [self init];
+    if (self != nil) {
+        [self setFontSymbolicTraits:fontSymbolicTraits];
+    }
+    return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    CMStyleAttributes * copiedAttributes = [CMStyleAttributes new];
+    [copiedAttributes.stringAttributes addEntriesFromDictionary:_stringAttributes];
+    [copiedAttributes.fontAttributes addEntriesFromDictionary:_fontAttributes];
+    [copiedAttributes.paragraphStyleAttributes addEntriesFromDictionary:_paragraphStyleAttributes];
+    return copiedAttributes;
+}
+
+- (void) setFontSymbolicTraits:(CMFontSymbolicTraits)fontSymbolicTraits
+{
+#if TARGET_OS_IPHONE
+    NSDictionary<UIFontDescriptorTraitKey, id> * currentFontTraits = _fontAttributes[UIFontDescriptorTraitsAttribute];
+    if (currentFontTraits == nil) {
+        _fontAttributes[UIFontDescriptorTraitsAttribute] = @{ UIFontSymbolicTrait: @(fontSymbolicTraits) };
+    }
+    else {
+        NSMutableDictionary* newFontTraits = currentFontTraits.mutableCopy;
+        newFontTraits[UIFontSymbolicTrait] = @(fontSymbolicTraits);
+        _fontAttributes[UIFontDescriptorTraitsAttribute] = newFontTraits;
+    }
+#else
+    NSDictionary<NSFontDescriptorTraitKey, id> * currentFontTraits = _fontAttributes[NSFontTraitsAttribute];
+    if (currentFontTraits == nil) {
+        _fontAttributes[NSFontTraitsAttribute] = @{ NSFontSymbolicTrait: @(fontSymbolicTraits) };
+    }
+    else {
+        NSMutableDictionary* newFontTraits = currentFontTraits.mutableCopy;
+        newFontTraits[NSFontSymbolicTrait] = @(fontSymbolicTraits);
+        _fontAttributes[NSFontTraitsAttribute] = newFontTraits;
+    }
+#endif
+}
+
+@end
+
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineSpacing = @"lineSpacing";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeParagraphSpacing = @"paragraphSpacing";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeAlignment = @"alignment";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeFirstLineHeadExtraIndent = @"firstLineHeadIndent";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeHeadExtraIndent = @"headIndent";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeTailExtraIndent = @"tailIndent";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineBreakMode = @"lineBreakMode";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeMinimumLineHeight = @"minimumLineHeight";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeMaximumLineHeight = @"maximumLineHeight";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeLineHeightMultiple = @"lineHeightMultiple";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeParagraphSpacingBefore = @"paragraphSpacingBefore";
+CMParagraphStyleAttributeName const CMParagraphStyleAttributeHyphenationFactor = @"hyphenationFactor";

--- a/Example-Mac/AppDelegate.swift
+++ b/Example-Mac/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             document?.linksBaseURL = linksBaseUrl
         }
         
-        let textAttributes = CMTextAttributes()!;
+        let textAttributes = CMTextAttributes()
         
         // Customize the color and font of header elements
         textAttributes.addStringAttributes([ .foregroundColor: NSColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], forElementWithKinds: .anyHeader)

--- a/Example-Mac/AppDelegate.swift
+++ b/Example-Mac/AppDelegate.swift
@@ -55,7 +55,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             document?.linksBaseURL = linksBaseUrl
         }
         
-        let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())!
+        let textAttributes = CMTextAttributes()!;
+        
+        // Customize the color and font of header elements
+        textAttributes.addStringAttributes([ .foregroundColor: NSColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], forElementWithKinds: .anyHeader)
+        if #available(OSX 10.11, *) {
+            textAttributes.addFontAttributes([ .family: "Avenir Next" ,
+                                                .traits: [ NSFontDescriptor.TraitKey.symbolic: NSFontDescriptor.SymbolicTraits.italic.rawValue,
+                                                           NSFontDescriptor.TraitKey.weight: NSFont.Weight.semibold]], 
+                                              forElementWithKinds: .anyHeader)
+            // Set specific font traits for header1 and header2
+            textAttributes.setFontTraits([.weight: NSFont.Weight.heavy], forElementWithKinds: [.header1, .header2])
+        } 
+        textAttributes.addFontAttributes([ .size: 48 ], forElementWithKinds: .header1)
+        
+        // Customize the font and paragraph alignment of block-quotes
+        textAttributes.addFontAttributes([.family: "Snell Roundhand", .size: 19], forElementWithKinds: .blockQuote)
+        textAttributes.addParagraphStyleAttributes([ .alignment: NSTextAlignment.center.rawValue], forElementWithKinds: .blockQuote)
+        
+        // Customize the background color of code elements
+        textAttributes.addStringAttributes([ .backgroundColor: NSColor(white: 0.9, alpha: 0.5)], forElementWithKinds: [.inlineCode, .codeBlock])
+        
+        let renderer = CMAttributedStringRenderer(document: document, attributes: textAttributes)!
         renderer.register(CMHTMLStrikethroughTransformer())
         renderer.register(CMHTMLSuperscriptTransformer())
         renderer.register(CMHTMLUnderlineTransformer())

--- a/Example-iOS/ViewController.swift
+++ b/Example-iOS/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UIViewController {
         let path = Bundle.main.path(forResource: "test", ofType: "md")!
         let document = CMDocument(contentsOfFile: path, options: CMDocumentOptions(rawValue: 0))
         
-        let textAttributes = CMTextAttributes()!;
+        let textAttributes = CMTextAttributes()
         
         // Customize the color and font of header elements
         textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], forElementWithKinds: .anyHeader)

--- a/Example-iOS/ViewController.swift
+++ b/Example-iOS/ViewController.swift
@@ -17,7 +17,25 @@ class ViewController: UIViewController {
         let path = Bundle.main.path(forResource: "test", ofType: "md")!
         let document = CMDocument(contentsOfFile: path, options: CMDocumentOptions(rawValue: 0))
         
-        let renderer = CMAttributedStringRenderer(document: document, attributes: CMTextAttributes())!
+        let textAttributes = CMTextAttributes()!;
+        
+        // Customize the color and font of header elements
+        textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], forElementWithKinds: .anyHeader)
+        let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic];
+        textAttributes.addFontAttributes([ .family: "Avenir Next" ,
+                                           .traits: [ UIFontDescriptor.TraitKey.symbolic: boldItalicTrait.rawValue]], 
+                                         forElementWithKinds: .anyHeader)
+        textAttributes.setFontTraits([.weight: UIFont.Weight.heavy], forElementWithKinds: [.header1, .header2])
+        textAttributes.addFontAttributes([ .size: 40 ], forElementWithKinds: .header1)
+        
+        // Customize the font and paragraph alignment of block-quotes
+        textAttributes.addFontAttributes([.family: "Noteworthy", .size: 18], forElementWithKinds: .blockQuote)
+        textAttributes.addParagraphStyleAttributes([ .alignment: NSTextAlignment.center.rawValue], forElementWithKinds: .blockQuote)
+        
+        // Customize the background color of code elements
+        textAttributes.addStringAttributes([ .backgroundColor: UIColor(white: 0.9, alpha: 0.5)], forElementWithKinds: [.inlineCode, .codeBlock])
+        
+        let renderer = CMAttributedStringRenderer(document: document, attributes: textAttributes)!
         renderer.register(CMHTMLStrikethroughTransformer())
         renderer.register(CMHTMLSuperscriptTransformer())
         renderer.register(CMHTMLUnderlineTransformer())

--- a/README.md
+++ b/README.md
@@ -82,18 +82,6 @@ Or, using the convenience method on `CMDocument`:
 textView.attributedText = CMDocument(contentsOfFile: path, options: nil).attributedStringWithAttributes(CMTextAttributes())
 ```
 
-All attributes used to style the text are customizable using the [`CMTextAttributes`](CocoaMarkdown/CMTextAttributes.h) class:
-
-```swift
-let attributes = CMTextAttributes()
-attributes.linkAttributes = [
-    NSForegroundColorAttributeName: UIColor.redColor()
-]
-attributes.emphasisAttributes = [
-    NSBackgroundColorAttributeName: UIColor.yellowColor()
-]
-```
-
 HTML elements can be supported by implementing [`CMHTMLElementTransformer`](CocoaMarkdown/CMHTMLElementTransformer.h). The framework includes several transformers for commonly used tags:
 
 * [`CMHTMLStrikethroughTransformer`](CocoaMarkdown/CMHTMLStrikethroughTransformer.h)
@@ -109,6 +97,54 @@ renderer.registerHTMLElementTransformer(CMHTMLStrikethroughTransformer())
 renderer.registerHTMLElementTransformer(CMHTMLSuperscriptTransformer())
 textView.attributedText = renderer.render()
 ```
+
+#### Customizing Attributed strings rendering
+
+All attributes used to style the text are customizable using the [`CMTextAttributes`](CocoaMarkdown/CMTextAttributes.h) class. 
+
+Every Markdown element type can be customized using the corresponding `CMStyleAttributes` property in `CMTextAttributes`, defining 3 different kinds of attributes:
+
+- String attributes, i.e. regular NSAttributedString attributes
+- Font attributes, for easy font setting 
+- Paragraph attributes, relevant only for block elements
+
+Attributes for any Markdown element kind can be directly set:
+
+```swift
+let textAttributes = CMTextAttributes()!
+textAttributes.linkAttributes.stringAttributes[NSAttributedString.Key.backgroundColor] = UIColor.yellow
+```
+
+A probably better alternative for style customization is to use grouped attributes setting methods available in `CMTextAttributes`:
+
+```swift
+let textAttributes = CMTextAttributes()!
+
+// Set the text color for all headers
+textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], 
+                                   forElementWithKinds: .anyHeader)
+
+// Set a specific font + font-traits for all headers
+let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic];
+textAttributes.addFontAttributes([ .family: "Avenir Next" ,
+                                   .traits: [ UIFontDescriptor.TraitKey.symbolic: boldItalicTrait.rawValue]], 
+                                 forElementWithKinds: .anyHeader)
+// Set specific font traits for header1 and header2
+textAttributes.setFontTraits([.weight: UIFont.Weight.heavy], 
+                             forElementWithKinds: [.header1, .header2])
+
+// Center block-quote paragraphs        
+textAttributes.addParagraphStyleAttributes([ .alignment: NSTextAlignment.center.rawValue], 
+                                           forElementWithKinds: .blockQuote)
+
+// Set a background color for code elements        
+textAttributes.addStringAttributes([ .backgroundColor: UIColor(white: 0.9, alpha: 0.5)], 
+                                   forElementWithKinds: [.inlineCode, .codeBlock])
+```
+
+Font and paragraph attributes are incremental, meaning that they allow to modify only specific aspects of the default rendering styles.
+
+Additionally on iOS, Markdown elements styled using the font attributes API get automatic Dynamic-Type compliance in the generated attributed string, just like default rendering styles.
 
 ### Rendering HTML
 


### PR DESCRIPTION
This PR is about bringing flexibility and ease-of-use to the attributed string renderer customization API.

Example of customization:

````swift
let textAttributes = CMTextAttributes()!;

// Customize the color and font of header elements
textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], 
                                   forElementWithKinds: .anyHeader)
let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic];
textAttributes.addFontAttributes([ .family: "Avenir Next" ,
                                   .traits: [ UIFontDescriptor.TraitKey.symbolic: boldItalicTrait.rawValue]], 
                                 forElementWithKinds: .anyHeader)
textAttributes.setFontTraits([.weight: UIFont.Weight.heavy], forElementWithKinds: [.header1, .header2])
textAttributes.addFontAttributes([ .size: 40 ], forElementWithKinds: .header1)

// Customize the font and paragraph alignment of block-quotes
textAttributes.addFontAttributes([.family: "Noteworthy", .size: 18], forElementWithKinds: .blockQuote)
textAttributes.addParagraphStyleAttributes([ .alignment: NSTextAlignment.center.rawValue], forElementWithKinds: .blockQuote)

// Customize the background color of code elements
textAttributes.addStringAttributes([ .backgroundColor: UIColor(white: 0.9, alpha: 0.5)], 
                                   forElementWithKinds: [.inlineCode, .codeBlock])

let renderer = CMAttributedStringRenderer(document: document, attributes: textAttributes)!
````

renders as:

![Capture d’écran 2019-11-04 à 13 55 46](https://user-images.githubusercontent.com/1850262/68122577-ea780200-ff0a-11e9-9e6b-080cee49e64c.png)


Note that on iOS, the rendered attributed string is fully compliant with dynamic type when customized font attributes are used.

Internal details (commit message):
- New class `CMStyleAttributes` provides an easier more-flexible way of styling Markdown elements. By exposing font attributes and paragraph attributes separately from other string attributes, `CMStyleAttributes` provides a simple way of  cascading attributes like font traits or paragraph headings.
- New incremental attributes setting APIs in `CMTextAttributes` allowing to add attributes to multiple Markdown element types at once.
- Attributes for element types strong and emphasis are now defined as regular defaults using font attributes.
- Simplified `CMCascadingAttributeStack` push/pop api.
- Updated README with description of the new attributes setting API.
- Updated example apps by adding attributes configuration sample code.

Misc:
- Render a code block as a single TextKit paragraph by replacing internal '\n' with line separators. This makes the definition of paragraph attributes on code blocks element consistent with other block types.