### PR TITLE
Corrected fix for flipped images on macOS 10.15.

### DIFF
--- a/CocoaMarkdown/CMImageTextAttachment.m
+++ b/CocoaMarkdown/CMImageTextAttachment.m
@@ -149,9 +149,12 @@ static NSImage* _placeholderImage;
     }    
     
 #if !TARGET_OS_IPHONE
-    if (! [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion: (NSOperatingSystemVersion){10, 15, 0}]) {
+#ifdef __MAC_10_15
+    if (! [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion: (NSOperatingSystemVersion){10, 15, 0}]) 
+#endif
+    {
         // On macOS 10.14.6 and below, the image attachment is dislayed vertically flipped, so we need to flip it again to display it correctly
-        // This issue has been fixed on macOS 10.15.
+        // This issue has been fixed on macOS 10.15 for applications compiled with Xcode 11 or later (SDK version >= 10.15)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [self.image setFlipped:NSGraphicsContext.currentContext.isFlipped];

--- a/Example-iOS/ViewController.swift
+++ b/Example-iOS/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         
         // Customize the color and font of header elements
         textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], forElementWithKinds: .anyHeader)
-        let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic];
+        let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic]
         textAttributes.addFontAttributes([ .family: "Avenir Next" ,
                                            .traits: [ UIFontDescriptor.TraitKey.symbolic: boldItalicTrait.rawValue]], 
                                          forElementWithKinds: .anyHeader)

--- a/README.md
+++ b/README.md
@@ -111,21 +111,21 @@ Every Markdown element type can be customized using the corresponding `CMStyleAt
 Attributes for any Markdown element kind can be directly set:
 
 ```swift
-let textAttributes = CMTextAttributes()!
+let textAttributes = CMTextAttributes()
 textAttributes.linkAttributes.stringAttributes[NSAttributedString.Key.backgroundColor] = UIColor.yellow
 ```
 
 A probably better alternative for style customization is to use grouped attributes setting methods available in `CMTextAttributes`:
 
 ```swift
-let textAttributes = CMTextAttributes()!
+let textAttributes = CMTextAttributes()
 
 // Set the text color for all headers
 textAttributes.addStringAttributes([ .foregroundColor: UIColor(red: 0.0, green: 0.446, blue: 0.657, alpha: 1.0)], 
                                    forElementWithKinds: .anyHeader)
 
 // Set a specific font + font-traits for all headers
-let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic];
+let boldItalicTrait: UIFontDescriptor.SymbolicTraits = [.traitBold, .traitItalic]
 textAttributes.addFontAttributes([ .family: "Avenir Next" ,
                                    .traits: [ UIFontDescriptor.TraitKey.symbolic: boldItalicTrait.rawValue]], 
                                  forElementWithKinds: .anyHeader)


### PR DESCRIPTION
Improved the original fix for flipped images in [b2397d6]: The SDK version used for generating the application shall be considered as well as the OS version on which the application is running (otherwise an application compiled with Xcode 10 and running on macOS 10,15 would show flipped images).

Thanks to @hisaac for reporting the issue!  (See the discussion at https://github.com/indragiek/CocoaMarkdown/pull/52#issuecomment-557681225)

*Also, to avoid creating a dedicated PR, this one includes a few minor typo fixes in the README :)*